### PR TITLE
Fix "OBJECT hits MONSTER" message for throw and fire commands

### DIFF
--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -919,7 +919,7 @@ static struct attack_result make_ranged_shot(struct player *p,
 	int multiplier = p->state.ammo_mult;
 	int b = 0, s = 0;
 
-	my_strcpy(hit_verb, "hits", sizeof(hit_verb));
+	my_strcpy(hit_verb, "hits", 20);
 
 	/* Did we hit it (penalize distance travelled) */
 	if (!test_hit(chance, mon->race->ac, monster_is_visible(mon)))
@@ -953,7 +953,7 @@ static struct attack_result make_ranged_throw(struct player *p,
 	int multiplier = 1;
 	int b = 0, s = 0;
 
-	my_strcpy(hit_verb, "hits", sizeof(hit_verb));
+	my_strcpy(hit_verb, "hits", 20);
 
 	/* If we missed then we're done */
 	if (!test_hit(chance, mon->race->ac, monster_is_visible(mon)))


### PR DESCRIPTION
Make make_ranged_shot() and make_ranged_throw() copy "hits" to hit_verb by using the allocated buffer size (20) instead of sizeof(hit_verb) as the length of the buffer. As the value of sizeof(hit_verb) is 4 in a 32-bit environment, my_strcpy only copies first three letters (the 4th element is the terminator '\0'). In the game, the bug made the message "OBJECT hit MONSTER" instead of "OBJECT hits MONSTER" (missing 's').